### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build and push to dockerhub
+permissions:
+  contents: read
 on:
   release:
     types: [released]


### PR DESCRIPTION
Potential fix for [https://github.com/schizo99/cowsay/security/code-scanning/1](https://github.com/schizo99/cowsay/security/code-scanning/1)

To fix this problem, you should add a `permissions` block to the workflow, either at the root level (so it applies to all jobs) or inside the relevant job block (here: `build-and-push`). Since this workflow does not seem to perform any write operations to repository contents, issues, or pull requests, the minimal required permission is likely `contents: read`, which allows jobs to check out repository code but not modify it. Add `permissions: contents: read` to the root of `.github/workflows/build.yaml`, immediately under the workflow name and before the `on:` block. No imports or method changes are required; just edit the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
